### PR TITLE
Fix depth-less Face Detector pipeline

### DIFF
--- a/OAKForUnity/URP/Assets/Plugins/OAKForUnity/Scripts/Predefined/FaceDetector/DaiFaceDetector.cs
+++ b/OAKForUnity/URP/Assets/Plugins/OAKForUnity/Scripts/Predefined/FaceDetector/DaiFaceDetector.cs
@@ -18,8 +18,8 @@ namespace OAKForUnity
         /*
         * Pipeline creation based on streams template
         *
-        * @param config pipeline configuration
-        * @returns pipeline
+        * @param config pipeline configuration 
+        * @returns pipeline 
         */
         private static extern bool InitFaceDetector(in PipelineConfig config);
 
@@ -36,38 +36,38 @@ namespace OAKForUnity
         * @param retrieveInformation True if system information is requested, False otherwise. Requires rate in pipeline creation.
         * @param useIMU True if IMU information is requested, False otherwise. Requires freq in pipeline creation.
         * @param deviceNum Device selection on unity dropdown
-        * @returns Json with results or information about device availability.
-        */
+        * @returns Json with results or information about device availability. 
+        */    
         private static extern IntPtr FaceDetectorResults(out FrameInfo frameInfo, bool getPreview, bool drawBestFaceInPreview, bool drawAllFacesInPreview, float faceScoreThreshold, bool useDepth, bool retrieveInformation, bool useIMU, int deviceNum);
 
-
+        
         // Editor attributes
-        [Header("RGB Camera")]
+        [Header("RGB Camera")] 
         public float cameraFPS = 30;
         public RGBResolution rgbResolution;
         private const bool Interleaved = false;
         private const ColorOrder ColorOrderV = ColorOrder.BGR;
 
-        [Header("Mono Cameras")]
+        [Header("Mono Cameras")] 
         public MonoResolution monoResolution;
 
-        [Header("Face Detector Configuration")]
+        [Header("Face Detector Configuration")] 
         public MedianFilter medianFilter;
         public bool useIMU = false;
         public bool retrieveSystemInformation = false;
         public bool drawBestFaceInPreview;
         public bool drawAllFacesInPreview;
-        public float faceScoreThreshold;
+        public float faceScoreThreshold; 
         private const bool GETPreview = true;
-        private const bool UseDepth = false;
+        private const bool UseDepth = true;
 
-        [Header("Face Detector Results")]
+        [Header("Face Detector Results")] 
         public Texture2D colorTexture;
         public string faceDetectorResults;
         public string systemInfo;
 
         [Header("Cube Character")] public GameObject cubeCharacter;
-
+        
         // private attributes
         private Color32[] _colorPixel32;
         private GCHandle _colorPixelHandle;
@@ -89,7 +89,7 @@ namespace OAKForUnity
         {
             // Init dataPath to load face detector NN model
             _dataPath = Application.dataPath;
-
+            
             InitTexture();
 
             // Init FrameInfo. Only need it in case memcpy data ptr on plugin lib.
@@ -107,7 +107,7 @@ namespace OAKForUnity
             // Need it for color camera preview
             config.previewSizeHeight = 300;
             config.previewSizeWidth = 300;
-
+            
             // Mono camera
             config.monoLCameraResolution = (int) monoResolution;
             config.monoRCameraResolution = (int) monoResolution;
@@ -136,11 +136,11 @@ namespace OAKForUnity
             if (useIMU) config.freq = 400;
             if (retrieveSystemInformation) config.rate = 30.0f;
             config.medianFilter = (int) medianFilter;
-
+            
             // Face NN model
             config.nnPath1 = _dataPath +
                              "/Plugins/OAKForUnity/Models/face-detection-retail-0004_openvino_2021.2_4shave.blob";
-
+            
             // Plugin lib init pipeline implementation
             deviceRunning = InitFaceDetector(config);
 
@@ -199,7 +199,7 @@ namespace OAKForUnity
             // EXAMPLE HOW TO PARSE INFO
             // Example JSON results from Face detection returned by the plugin
             // { "faces": [ {"label":0,"score":0.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,"ymax":0.0,"xcenter":0.0,"ycenter":0.0},{"label":1,"score":1.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,* "ymax":0.0,"xcenter":0.0,"ycenter":0.0}],"best":{"label":1,"score":1.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,"ymax":0.0,"xcenter":0.0,"ycenter":0.0},"fps":0.0}
-
+            
             var obj = JSON.Parse(faceDetectorResults);
             int centerx = 0;
             int centery = 0;
@@ -220,7 +220,7 @@ namespace OAKForUnity
 
                     device.Record(faceDetectorResults, textures, nameTextures);
                 }
-
+                
                 if (UseDepth)
                 {
                     int depthx = obj["best"]["X"];
@@ -236,9 +236,9 @@ namespace OAKForUnity
                 }
                 else cubeCharacter.transform.localPosition = new Vector3((float)(150-centerx)/100.0f,(float)-(centery-150)/100.0f,cubeCharacter.transform.localPosition.z);
             }
-
+            
             if (!retrieveSystemInformation || obj == null) return;
-
+            
             float ddrUsed = obj["sysinfo"]["ddr_used"];
             float ddrTotal = obj["sysinfo"]["ddr_total"];
             float cmxUsed = obj["sysinfo"]["cmx_used"];

--- a/OAKForUnity/URP/Assets/Plugins/OAKForUnity/Scripts/Predefined/FaceDetector/DaiFaceDetector.cs
+++ b/OAKForUnity/URP/Assets/Plugins/OAKForUnity/Scripts/Predefined/FaceDetector/DaiFaceDetector.cs
@@ -18,8 +18,8 @@ namespace OAKForUnity
         /*
         * Pipeline creation based on streams template
         *
-        * @param config pipeline configuration 
-        * @returns pipeline 
+        * @param config pipeline configuration
+        * @returns pipeline
         */
         private static extern bool InitFaceDetector(in PipelineConfig config);
 
@@ -36,38 +36,38 @@ namespace OAKForUnity
         * @param retrieveInformation True if system information is requested, False otherwise. Requires rate in pipeline creation.
         * @param useIMU True if IMU information is requested, False otherwise. Requires freq in pipeline creation.
         * @param deviceNum Device selection on unity dropdown
-        * @returns Json with results or information about device availability. 
-        */    
+        * @returns Json with results or information about device availability.
+        */
         private static extern IntPtr FaceDetectorResults(out FrameInfo frameInfo, bool getPreview, bool drawBestFaceInPreview, bool drawAllFacesInPreview, float faceScoreThreshold, bool useDepth, bool retrieveInformation, bool useIMU, int deviceNum);
 
-        
+
         // Editor attributes
-        [Header("RGB Camera")] 
+        [Header("RGB Camera")]
         public float cameraFPS = 30;
         public RGBResolution rgbResolution;
         private const bool Interleaved = false;
         private const ColorOrder ColorOrderV = ColorOrder.BGR;
 
-        [Header("Mono Cameras")] 
+        [Header("Mono Cameras")]
         public MonoResolution monoResolution;
 
-        [Header("Face Detector Configuration")] 
+        [Header("Face Detector Configuration")]
         public MedianFilter medianFilter;
         public bool useIMU = false;
         public bool retrieveSystemInformation = false;
         public bool drawBestFaceInPreview;
         public bool drawAllFacesInPreview;
-        public float faceScoreThreshold; 
+        public float faceScoreThreshold;
         private const bool GETPreview = true;
-        private const bool UseDepth = true;
+        private const bool UseDepth = false;
 
-        [Header("Face Detector Results")] 
+        [Header("Face Detector Results")]
         public Texture2D colorTexture;
         public string faceDetectorResults;
         public string systemInfo;
 
         [Header("Cube Character")] public GameObject cubeCharacter;
-        
+
         // private attributes
         private Color32[] _colorPixel32;
         private GCHandle _colorPixelHandle;
@@ -89,7 +89,7 @@ namespace OAKForUnity
         {
             // Init dataPath to load face detector NN model
             _dataPath = Application.dataPath;
-            
+
             InitTexture();
 
             // Init FrameInfo. Only need it in case memcpy data ptr on plugin lib.
@@ -107,7 +107,7 @@ namespace OAKForUnity
             // Need it for color camera preview
             config.previewSizeHeight = 300;
             config.previewSizeWidth = 300;
-            
+
             // Mono camera
             config.monoLCameraResolution = (int) monoResolution;
             config.monoRCameraResolution = (int) monoResolution;
@@ -136,11 +136,11 @@ namespace OAKForUnity
             if (useIMU) config.freq = 400;
             if (retrieveSystemInformation) config.rate = 30.0f;
             config.medianFilter = (int) medianFilter;
-            
+
             // Face NN model
             config.nnPath1 = _dataPath +
                              "/Plugins/OAKForUnity/Models/face-detection-retail-0004_openvino_2021.2_4shave.blob";
-            
+
             // Plugin lib init pipeline implementation
             deviceRunning = InitFaceDetector(config);
 
@@ -199,7 +199,7 @@ namespace OAKForUnity
             // EXAMPLE HOW TO PARSE INFO
             // Example JSON results from Face detection returned by the plugin
             // { "faces": [ {"label":0,"score":0.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,"ymax":0.0,"xcenter":0.0,"ycenter":0.0},{"label":1,"score":1.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,* "ymax":0.0,"xcenter":0.0,"ycenter":0.0}],"best":{"label":1,"score":1.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,"ymax":0.0,"xcenter":0.0,"ycenter":0.0},"fps":0.0}
-            
+
             var obj = JSON.Parse(faceDetectorResults);
             int centerx = 0;
             int centery = 0;
@@ -220,7 +220,7 @@ namespace OAKForUnity
 
                     device.Record(faceDetectorResults, textures, nameTextures);
                 }
-                
+
                 if (UseDepth)
                 {
                     int depthx = obj["best"]["X"];
@@ -236,9 +236,9 @@ namespace OAKForUnity
                 }
                 else cubeCharacter.transform.localPosition = new Vector3((float)(150-centerx)/100.0f,(float)-(centery-150)/100.0f,cubeCharacter.transform.localPosition.z);
             }
-            
+
             if (!retrieveSystemInformation || obj == null) return;
-            
+
             float ddrUsed = obj["sysinfo"]["ddr_used"];
             float ddrTotal = obj["sysinfo"]["ddr_total"];
             float cmxUsed = obj["sysinfo"]["cmx_used"];


### PR DESCRIPTION
Hi @gespona,

Currently, the Dai Face Detector script crashes when setting `UseDepth` to false. This is because some cases were not handled in the source library.

This PR adds those checks. I also changed the default `UseDepth` to false, to show the intention, but I could revert it.

The rest of the diff is just whitespace, so you can look at it with the whitespace ignore option.