### PR TITLE
Investigating a depth-less Object Detector that does not crash

### DIFF
--- a/src/predefined/ObjectDetector.cpp
+++ b/src/predefined/ObjectDetector.cpp
@@ -47,27 +47,27 @@ static const std::vector<std::string> labelMap = {
 /**
 * Pipeline creation based on streams template
 *
-* @param config pipeline configuration 
-* @returns pipeline 
+* @param config pipeline configuration
+* @returns pipeline
 */
 dai::Pipeline createObjectDetectorPipeline(PipelineConfig *config)
 {
     dai::Pipeline pipeline;
     std::shared_ptr<dai::node::XLinkOut> xlinkOut;
 
-    auto spatialDetectionNetwork = pipeline.create<dai::node::YoloSpatialDetectionNetwork>();
+    auto spatialDetectionNetwork = pipeline.create<dai::node::YoloDetectionNetwork>();
 
     auto colorCam = pipeline.create<dai::node::ColorCamera>();
 
     // Color camera preview
-    if (config->previewSizeWidth > 0 && config->previewSizeHeight > 0) 
+    if (config->previewSizeWidth > 0 && config->previewSizeHeight > 0)
     {
         xlinkOut = pipeline.create<dai::node::XLinkOut>();
         xlinkOut->setStreamName("preview");
         colorCam->setPreviewSize(config->previewSizeWidth, config->previewSizeHeight);
     }
 
-    // Color camera properties            
+    // Color camera properties
     colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
     if (config->colorCameraResolution == 1) colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_4_K);
     if (config->colorCameraResolution == 2) colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_12_MP);
@@ -81,9 +81,6 @@ dai::Pipeline createObjectDetectorPipeline(PipelineConfig *config)
     spatialDetectionNetwork->setBlobPath(config->nnPath1);
     spatialDetectionNetwork->setConfidenceThreshold(0.5f);
     spatialDetectionNetwork->input.setBlocking(false);
-    spatialDetectionNetwork->setBoundingBoxScaleFactor(0.5);
-    spatialDetectionNetwork->setDepthLowerThreshold(100);
-    spatialDetectionNetwork->setDepthUpperThreshold(5000);
 
     // yolo specific parameters
     spatialDetectionNetwork->setNumClasses(80);
@@ -97,61 +94,8 @@ dai::Pipeline createObjectDetectorPipeline(PipelineConfig *config)
 
     // output of neural network
     auto nnOut = pipeline.create<dai::node::XLinkOut>();
-    nnOut->setStreamName("detections");    
-
-    // Depth
-    if (config->confidenceThreshold > 0)
-    {
-        auto left = pipeline.create<dai::node::MonoCamera>();
-        auto right = pipeline.create<dai::node::MonoCamera>();
-        auto stereo = pipeline.create<dai::node::StereoDepth>();
-
-        // For RGB-Depth align
-        if (config->ispScaleF1 > 0 && config->ispScaleF2 > 0) colorCam->setIspScale(config->ispScaleF1, config->ispScaleF2);
-        if (config->manualFocus > 0) colorCam->initialControl.setManualFocus(config->manualFocus);
-
-        // Mono camera properties    
-        left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-        if (config->monoLCameraResolution == 1) left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-        if (config->monoLCameraResolution == 2) left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_800_P);
-        if (config->monoLCameraResolution == 3) left->setResolution(dai::MonoCameraProperties::SensorResolution::THE_480_P);
-        left->setBoardSocket(dai::CameraBoardSocket::LEFT);
-        right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
-        if (config->monoRCameraResolution == 1) right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_720_P);
-        if (config->monoRCameraResolution == 2) right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_800_P);
-        if (config->monoRCameraResolution == 3) right->setResolution(dai::MonoCameraProperties::SensorResolution::THE_480_P);
-        right->setBoardSocket(dai::CameraBoardSocket::RIGHT);
-
-        // Stereo properties
-        stereo->setConfidenceThreshold(config->confidenceThreshold);
-        // LR-check is required for depth alignment
-        stereo->setLeftRightCheck(config->leftRightCheck);
-        if (config->depthAlign > 0) stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
-        stereo->setSubpixel(config->subpixel);
-        
-        stereo->initialConfig.setMedianFilter(dai::MedianFilter::MEDIAN_OFF);
-        if (config->medianFilter == 1) stereo->initialConfig.setMedianFilter(dai::MedianFilter::KERNEL_3x3);
-        if (config->medianFilter == 2) stereo->initialConfig.setMedianFilter(dai::MedianFilter::KERNEL_5x5);
-        if (config->medianFilter == 3) stereo->initialConfig.setMedianFilter(dai::MedianFilter::KERNEL_7x7);
-
-        // Linking
-        left->out.link(stereo->left);
-        right->out.link(stereo->right);
-        auto xoutDepth = pipeline.create<dai::node::XLinkOut>();            
-        xoutDepth->setStreamName("depth");
-        stereo->depth.link(xoutDepth->input);
-
-        
-        auto xoutBoundingBoxDepthMapping = pipeline.create<dai::node::XLinkOut>();
-        xoutBoundingBoxDepthMapping->setStreamName("boundingBoxDepthMapping");
-
-        spatialDetectionNetwork->out.link(nnOut->input);
-        spatialDetectionNetwork->boundingBoxMapping.link(xoutBoundingBoxDepthMapping->input);
-
-        stereo->depth.link(spatialDetectionNetwork->inputDepth);
-        spatialDetectionNetwork->passthroughDepth.link(xoutDepth->input);
-
-    }
+    nnOut->setStreamName("detections");
+    spatialDetectionNetwork->out.link(nnOut->input);
 
     // SYSTEM INFORMATION
     if (config->rate > 0.0f)
@@ -198,8 +142,8 @@ extern "C"
    /**
     * Pipeline creation based on streams template
     *
-    * @param config pipeline configuration 
-    * @returns pipeline 
+    * @param config pipeline configuration
+    * @returns pipeline
     */
     EXPORT_API bool InitObjectDetector(PipelineConfig *config)
     {
@@ -208,9 +152,9 @@ extern "C"
         // If deviceId is empty .. just pick first available device
         bool res = false;
 
-        if (strcmp(config->deviceId,"NONE")==0 || strcmp(config->deviceId,"")==0) res = DAIStartPipeline(pipeline,config->deviceNum,NULL);        
+        if (strcmp(config->deviceId,"NONE")==0 || strcmp(config->deviceId,"")==0) res = DAIStartPipeline(pipeline,config->deviceNum,NULL);
         else res = DAIStartPipeline(pipeline,config->deviceNum,config->deviceId);
-        
+
         return res;
     }
 
@@ -219,19 +163,18 @@ extern "C"
     *
     * @param frameInfo camera images pointers
     * @param getPreview True if color preview image is requested, False otherwise. Requires previewSize in pipeline creation.
-    * @param useDepth True if depth information is requested, False otherwise. Requires confidenceThreshold in pipeline creation.
     * @param retrieveInformation True if system information is requested, False otherwise. Requires rate in pipeline creation.
     * @param useIMU True if IMU information is requested, False otherwise. Requires freq in pipeline creation.
     * @param deviceNum Device selection on unity dropdown
-    * @returns Json with results or information about device availability. 
-    */    
+    * @returns Json with results or information about device availability.
+    */
 
     /**
     * Example of json returned
     * { "objects": [ {"label":"object","score":0.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,"ymax":0.0,"xcenter":0.0,"ycenter":0.0},{"label":1,"score":1.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,* "ymax":0.0,"xcenter":0.0,"ycenter":0.0}],"best":{"label":1,"score":1.0,"xmin":0.0,"ymin":0.0,"xmax":0.0,"ymax":0.0,"xcenter":0.0,"ycenter":0.0},"fps":0.0}
     */
 
-    EXPORT_API const char* ObjectDetectorResults(FrameInfo *frameInfo, bool getPreview, float objectScoreThreshold, bool useDepth, bool retrieveInformation, bool useIMU, int deviceNum)
+    EXPORT_API const char* ObjectDetectorResults(FrameInfo *frameInfo, bool getPreview, float objectScoreThreshold, bool retrieveInformation, bool useIMU, int deviceNum)
     {
         using namespace std;
         using namespace std::chrono;
@@ -239,7 +182,7 @@ extern "C"
         // Get device deviceNum
         std::shared_ptr<dai::Device> device = GetDevice(deviceNum);
         // Device no available
-        if (device == NULL) 
+        if (device == NULL)
         {
             char* ret = (char*)::malloc(strlen("{\"error\":\"NO_DEVICE\"}"));
             ::memcpy(ret, "{\"error\":\"NO_DEVICE\"}",strlen("{\"error\":\"NO_DEVICE\"}"));
@@ -254,52 +197,23 @@ extern "C"
             nlohmann::json objectDetectorJson = {};
 
             std::shared_ptr<dai::DataOutputQueue> preview;
-            std::shared_ptr<dai::DataOutputQueue> depthQueue;
-            
+
             // object detector results
             auto detectionNNQueue = device->getOutputQueue("detections",4,false);
-            
+
             // if preview image is requested. True in this case.
             if (getPreview) preview = device->getOutputQueue("preview",4,false);
-            
-            // if depth images are requested. All images.
-            if (useDepth) depthQueue = device->getOutputQueue("depth", 4, false);
-            
-            auto xoutBoundingBoxDepthMappingQueue = device->getOutputQueue("boundingBoxDepthMapping", 4, false);
 
-            int countd;
             auto color = cv::Scalar(255, 255, 255);
 
             auto imgFrame = preview->get<dai::ImgFrame>();
-            auto inDet = detectionNNQueue->get<dai::SpatialImgDetections>();
-            auto depth = depthQueue->get<dai::ImgFrame>();
+            auto inDet = detectionNNQueue->get<dai::ImgDetections>();
 
-            cv::Mat frame = imgFrame->getCvFrame();
-            cv::Mat depthFrame = depth->getFrame();
+            auto frame = imgFrame->getCvFrame();
 
-            int count;
-            // In this case we allocate before Texture2D (ARGB32) and memcpy pointer data 
-            
+            // In this case we allocate before Texture2D (ARGB32) and memcpy pointer data
+
             auto detections = inDet->detections;
-            if(!detections.empty()) {
-                
-                auto boundingBoxMapping = xoutBoundingBoxDepthMappingQueue->get<dai::SpatialLocationCalculatorConfig>();
-                auto roiDatas = boundingBoxMapping->getConfigData();
-
-                for(auto roiData : roiDatas) {
-                    auto roi = roiData.roi;
-                    roi = roi.denormalize(depthFrame.cols, depthFrame.rows);
-                    auto topLeft = roi.topLeft();
-                    auto bottomRight = roi.bottomRight();
-                    auto xmin = (int)topLeft.x;
-                    auto ymin = (int)topLeft.y;
-                    auto xmax = (int)bottomRight.x;
-                    auto ymax = (int)bottomRight.y;
-
-                    cv::rectangle(depthFrame, cv::Rect(cv::Point(xmin, ymin), cv::Point(xmax, ymax)), color, cv::FONT_HERSHEY_SIMPLEX);
-                }
-            }
-
             nlohmann::json objectsArr = {};
 
             for(const auto& detection : detections) {
@@ -315,20 +229,17 @@ extern "C"
                     labelStr = labelMap[labelIndex];
                 }
 
-                if (detection.confidence>=objectScoreThreshold) 
+                if (detection.confidence>=objectScoreThreshold)
                 {
                     cv::rectangle(frame, cv::Rect(cv::Point(x1, y1), cv::Point(x2, y2)), color, cv::FONT_HERSHEY_SIMPLEX);
-                
+
                     nlohmann::json object;
                     object["label"] = labelStr;
                     object["score"] = detection.confidence * 100;
-                    object["xmin"] = x1; 
-                    object["xmax"] = x2; 
-                    object["ymin"] = y1; 
-                    object["ymax"] = y2; 
-                    object["X"] = (int)detection.spatialCoordinates.x;
-                    object["Y"] = (int)detection.spatialCoordinates.y;
-                    object["Z"] = (int)detection.spatialCoordinates.z;
+                    object["xmin"] = x1;
+                    object["xmax"] = x2;
+                    object["ymin"] = y1;
+                    object["ymax"] = y2;
 
                     objectsArr.push_back(object);
                 }
@@ -339,7 +250,7 @@ extern "C"
             objectDetectorJson["objects"] = objectsArr;
 
             // SYSTEM INFORMATION
-            if (retrieveInformation) objectDetectorJson["sysinfo"] = GetDeviceInfo(device);        
+            if (retrieveInformation) objectDetectorJson["sysinfo"] = GetDeviceInfo(device);
             // IMU
             if (useIMU) objectDetectorJson["imu"] = GetIMU(device);
 


### PR DESCRIPTION
To address https://github.com/luxonis/depthai-unity/issues/65#issue-2592362035, This PR investigates if one can run a depth-less YoloDetector without crashing.

I wouldn't merge the PR as is, as it removes the depth estimation, which is what makes the interactive part of the scene. 
Still, with this configuration and even using a newer version of a Yolo network (optional), my OAK-D Lite does not crash.

It could be that the previous pipeline was crashing due to overheating, as it would crash at random times, sometimes early in the scene, sometimes a few minutes in, but that would not necessarily explain very early crashes. 
I also have no other device against which to test this.

Using any configuration for a [YoloSpatialDetectionNetwork](https://docs.luxonis.com/software/depthai-components/nodes/yolo_spatial_detection_network/) instead of a [YoloDetectionNetwork](https://docs.luxonis.com/software/depthai-components/nodes/yolo_detection_network/#depthai.node.YoloDetectionNetwork.setIouThreshold) does eventually lead to a crash on my OAK-D Lite. Tested with blobs from yolov3, yolov4, and the latest blob I could find in the Luxonis artifacts, yolov8.